### PR TITLE
Add ARM64 support in the configure file - Create virtualbox-guest-additions-7.1-arm64.patch

### DIFF
--- a/app-emulation/virtualbox-guest-additions/files/virtualbox-guest-additions-7.1-arm64.patch
+++ b/app-emulation/virtualbox-guest-additions/files/virtualbox-guest-additions-7.1-arm64.patch
@@ -1,0 +1,13 @@
+--- a/configure
++++ b/configure
+@@ -421,6 +421,10 @@ EOF
+         BUILD_MACHINE='sparc32'
+         BUILD_CPU='blend'
+         ;;
++    aarch64)
++        BUILD_MACHINE='arm64'
++        BUILD_CPU='blend'
++        ;;
+     *)
+       log_failure "Cannot determine system"
+       exit 1


### PR DESCRIPTION
Add ARM64 support in the configure file


---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
